### PR TITLE
[FEATURE] Add ability to tune sysctl setting

### DIFF
--- a/root/etc/cont-init.d/05-tune-sysctl-settings
+++ b/root/etc/cont-init.d/05-tune-sysctl-settings
@@ -1,0 +1,19 @@
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
+
+umask "${UMASK}"
+
+if [[ "${SYSCTL_MAX_USER_WATCHES}" -gt 0 ]]; then
+    echo "Attempting to update max_user_watches sysctl setting"
+
+    echo "fs.inotify.max_user_watches=${SYSCTL_MAX_USER_WATCHES}" >> /etc/sysctl.conf
+
+    sysctl -p && UPDATED_OK="yes"
+
+    if [[ "${INSTALL_OK}" != "yes" ]]; then
+        echo -e '\e[31m'"Updating fs.inotify.max_user_watches failed!"'\e[0m'
+        exit 1
+    else
+        echo "Updating fs.inotify.max_user_watches succeeded."
+    fi
+fi


### PR DESCRIPTION
For large libraries (where there are more than 8192 folders), this will overload the `notify` table on linux and mean that any other services that rely on it cannot use it. This impacts EAE particularly, where it will start to fail to transcode audio. 

this overlay will theoretically set the correct sysctl setting to resolve that.